### PR TITLE
Fix: PyPI Logo Rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
     <a href="https://pydantic-argparse.supimdos.com">
-        <img src="docs/assets/images/logo.svg" width="50%">
+        <img src="https://raw.githubusercontent.com/SupImDos/pydantic-argparse/master/docs/assets/images/logo.svg" width="50%">
     </a>
     <h1>
         Pydantic Argparse


### PR DESCRIPTION
### Changes
* Update `README.md` to use raw Github logo link, rather than local path
* This will allow the PyPI markdown renderer to display the logo