### PR TITLE
Enhancement: Pydantic v2 Package Shim Compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Hatch
         run: pip install git+https://github.com/pypa/hatch.git@master
       - name: Install Pydantic
-        run: pip install {{ matrix.pydantic-version }}
+        run: pip install ${{ matrix.pydantic-version }}
       - name: Run Build Hooks
         run: hatch build --hooks-only
       - name: Run Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ "ubuntu-latest", "macos-13", "windows-latest" ]
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
-        pydantic-version: [ "pydantic~=1.0", "pydantic~=2.0" ]
+        pydantic-version: [ "1.0", "2.0" ]
       fail-fast: false
     defaults:
       run:
@@ -39,7 +39,7 @@ jobs:
       - name: Install Hatch
         run: pip install git+https://github.com/pypa/hatch.git@master
       - name: Install Pydantic
-        run: hatch run uv pip install ${{ matrix.pydantic-version }}
+        run: hatch run uv pip install pydantic~=${{ matrix.pydantic-version }}
       - name: Run Build Hooks
         run: hatch build --hooks-only
       - name: Run Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ "ubuntu-latest", "macos-13", "windows-latest" ]
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
-        pydantic-version: [ "pydantic>=1,<2", "pydantic>=2,<3" ]
+        pydantic-version: [ "pydantic~=1.0", "pydantic~=2.0" ]
       fail-fast: false
     defaults:
       run:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Hatch
         run: pip install git+https://github.com/pypa/hatch.git@master
       - name: Install Pydantic
-        run: pip install ${{ matrix.pydantic-version }}
+        run: hatch run uv pip install ${{ matrix.pydantic-version }}
       - name: Run Build Hooks
         run: hatch build --hooks-only
       - name: Run Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         os: [ "ubuntu-latest", "macos-13", "windows-latest" ]
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        pydantic-version: [ "pydantic>=1,<2", "pydantic>=2,<3" ]
       fail-fast: false
     defaults:
       run:
@@ -34,9 +35,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.pydantic-version }}-${{ hashFiles('pyproject.toml') }}
       - name: Install Hatch
         run: pip install git+https://github.com/pypa/hatch.git@master
+      - name: Install Pydantic
+        run: pip install {{ matrix.pydantic-version }}
       - name: Run Build Hooks
         run: hatch build --hooks-only
       - name: Run Tests
@@ -45,7 +48,7 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: ${{ matrix.os }}-${{ matrix.python-version }}
+          flag-name: ${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.pydantic-version }}
           parallel: true
 
   coverage:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@
 ## Help
 See [documentation](https://pydantic-argparse.supimdos.com) for help.
 
+## Requirements
+Requires Python 3.8+, and is compatible with the Pydantic v1 API.
+
 ## Installation
 Installation with `pip` is simple:
 ```console
@@ -46,7 +49,7 @@ $ pip install pydantic-argparse
 
 ## Example
 ```py
-import pydantic
+import pydantic.v1 as pydantic
 import pydantic_argparse
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,8 @@
 provides declarative *typed* argument parsing using `pydantic` models.
 
 ## Requirements
-`pydantic-argparse` requires Python 3.8+
+`pydantic-argparse` requires Python 3.8+, and is compatible with the Pydantic
+v1 API.
 
 ## Installation
 Installation with `pip` is simple:

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -7,7 +7,7 @@ The `pydantic-argparse` command-line interface construction is simple.
 
 === "Pydantic Argparse"
     ```python
-    import pydantic
+    import pydantic.v1 as pydantic
     import pydantic_argparse
 
     # Declare Arguments

--- a/examples/commands.py
+++ b/examples/commands.py
@@ -2,7 +2,7 @@
 
 
 # Third-Party
-import pydantic
+import pydantic.v1 as pydantic
 import pydantic_argparse
 
 # Typing

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -2,7 +2,7 @@
 
 
 # Third-Party
-import pydantic
+import pydantic.v1 as pydantic
 import pydantic_argparse
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ warn_return_any = true
 warn_unused_ignores = true
 no_implicit_optional = true
 show_error_codes = true
-plugins = ["pydantic.mypy"]
+plugins = ["pydantic.v1.mypy"]
 
 [tool.pydantic-mypy]
 init_forbid_extra = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [{ name = "Hayden Richards", email = "supimdos@gmail.com" }]
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.8"
-dependencies = ["pydantic<2"]
+dependencies = ["pydantic"]
 classifiers = [
     "Development Status :: 4 - Beta",
     'Programming Language :: Python',

--- a/src/pydantic_argparse/argparse/actions.py
+++ b/src/pydantic_argparse/argparse/actions.py
@@ -7,8 +7,8 @@ Python standard library `argparse` class of the same name.
 """
 
 
-# Standard
-import argparse
+# Local
+from pydantic_argparse.compatibility import argparse
 
 # Typing
 from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, TypeVar, Union, cast

--- a/src/pydantic_argparse/argparse/parser.py
+++ b/src/pydantic_argparse/argparse/parser.py
@@ -21,7 +21,7 @@ import sys
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic
+    import pydantic.v1 as pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/src/pydantic_argparse/argparse/parser.py
+++ b/src/pydantic_argparse/argparse/parser.py
@@ -16,17 +16,14 @@ be compatible with an IDE, linter or type checker.
 
 
 # Standard
-import argparse
 import sys
-
-# Third-Party
-import pydantic.v1 as pydantic
 
 # Local
 from pydantic_argparse import parsers
 from pydantic_argparse import utils
 from pydantic_argparse.argparse import actions
-from pydantic_argparse.argparse import patches  # noqa: F401
+from pydantic_argparse.compatibility import argparse
+from pydantic_argparse.compatibility import pydantic
 
 # Typing
 from typing import Any, Dict, Generic, List, NoReturn, Optional, Type, TypeVar

--- a/src/pydantic_argparse/argparse/parser.py
+++ b/src/pydantic_argparse/argparse/parser.py
@@ -20,10 +20,7 @@ import argparse
 import sys
 
 # Third-Party
-try:  # pragma: no cover
-    import pydantic.v1 as pydantic
-except ImportError:  # pragma: no cover
-    import pydantic  # type: ignore[no-redef]
+import pydantic.v1 as pydantic
 
 # Local
 from pydantic_argparse import parsers

--- a/src/pydantic_argparse/argparse/parser.py
+++ b/src/pydantic_argparse/argparse/parser.py
@@ -20,7 +20,10 @@ import argparse
 import sys
 
 # Third-Party
-import pydantic
+try:  # pragma: no cover
+    import pydantic.v1 as pydantic
+except ImportError:  # pragma: no cover
+    import pydantic  # type: ignore[no-redef]
 
 # Local
 from pydantic_argparse import parsers

--- a/src/pydantic_argparse/argparse/parser.py
+++ b/src/pydantic_argparse/argparse/parser.py
@@ -21,7 +21,7 @@ import sys
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic.v1 as pydantic
+    import pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/src/pydantic_argparse/compatibility/__init__.py
+++ b/src/pydantic_argparse/compatibility/__init__.py
@@ -1,0 +1,11 @@
+"""Compatibiltity Shims for Declarative Typed Argument Parsing.
+
+This package contains compatibility shims for the `pydantic` and `argparse`
+modules, so that we can properly maintain version compatibility in one place.
+
+The public interface exposed by this package is the module shims themselves.
+"""
+
+# Local
+from pydantic_argparse.compatibility.argparse import argparse as argparse
+from pydantic_argparse.compatibility.pydantic import pydantic as pydantic

--- a/src/pydantic_argparse/compatibility/argparse.py
+++ b/src/pydantic_argparse/compatibility/argparse.py
@@ -1,4 +1,4 @@
-"""Monkey patches for ArgumentParser.
+"""Compatibility Shim for ArgumentParser.
 
 In order to support Python 3.8 while retaining the unit tests, we need to
 backport the bugfix for [`BPO-29298`](https://bugs.python.org/issue29298).

--- a/src/pydantic_argparse/compatibility/pydantic.py
+++ b/src/pydantic_argparse/compatibility/pydantic.py
@@ -2,6 +2,7 @@
 
 In order to support both Pydantic v1 and Pydantic v2, we need to make sure we
 import the module correctly:
+
 * For `pydantic~=2.0` there is a working `v1` module.
 * For `pydantic==1.10.15` there is a broken `v1` module (with no `fields`).
 * For `pydantic<1.10.14` there is no `v1` module.

--- a/src/pydantic_argparse/compatibility/pydantic.py
+++ b/src/pydantic_argparse/compatibility/pydantic.py
@@ -15,5 +15,11 @@ import the module correctly:
 try:  # pragma: no cover
     from pydantic import v1 as pydantic
     pydantic.fields  # noqa: B018
+    # Test
+    import pydantic  # type: ignore[no-redef]
+    assert pydantic.__version__.startswith("2")
+    from pydantic import v1 as pydantic
 except (ImportError, AttributeError):  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
+    # Test
+    assert pydantic.__version__.startswith("1")

--- a/src/pydantic_argparse/compatibility/pydantic.py
+++ b/src/pydantic_argparse/compatibility/pydantic.py
@@ -15,11 +15,5 @@ import the module correctly:
 try:  # pragma: no cover
     from pydantic import v1 as pydantic
     pydantic.fields  # noqa: B018
-    # Test
-    import pydantic  # type: ignore[no-redef]
-    assert pydantic.__version__.startswith("2")
-    from pydantic import v1 as pydantic
 except (ImportError, AttributeError):  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
-    # Test
-    assert pydantic.__version__.startswith("1")

--- a/src/pydantic_argparse/compatibility/pydantic.py
+++ b/src/pydantic_argparse/compatibility/pydantic.py
@@ -1,0 +1,18 @@
+"""Compatibility Shim for Pydantic.
+
+In order to support both Pydantic v1 and Pydantic v2, we need to make sure we
+import the module correctly:
+* For `pydantic~=2.0` there is a working `v1` module.
+* For `pydantic==1.10.15` there is a broken `v1` module (with no `fields`).
+* For `pydantic<1.10.14` there is no `v1` module.
+"""
+
+
+# Pydantic Shim
+# There is a bit of fiddling around here to accomodate for the cases outlined
+# above, as well as to keep the type-checker and language-server happy.
+try:  # pragma: no cover
+    from pydantic import v1 as pydantic
+    pydantic.fields  # noqa: B018
+except (ImportError, AttributeError):  # pragma: no cover
+    import pydantic  # type: ignore[no-redef]

--- a/src/pydantic_argparse/parsers/boolean.py
+++ b/src/pydantic_argparse/parsers/boolean.py
@@ -12,7 +12,7 @@ import argparse
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic
+    import pydantic.v1 as pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/src/pydantic_argparse/parsers/boolean.py
+++ b/src/pydantic_argparse/parsers/boolean.py
@@ -11,7 +11,10 @@ command-line arguments.
 import argparse
 
 # Third-Party
-import pydantic
+try:  # pragma: no cover
+    import pydantic.v1 as pydantic
+except ImportError:  # pragma: no cover
+    import pydantic  # type: ignore[no-redef]
 
 # Typing
 from typing import Optional

--- a/src/pydantic_argparse/parsers/boolean.py
+++ b/src/pydantic_argparse/parsers/boolean.py
@@ -12,7 +12,7 @@ import argparse
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic.v1 as pydantic
+    import pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/src/pydantic_argparse/parsers/boolean.py
+++ b/src/pydantic_argparse/parsers/boolean.py
@@ -11,10 +11,7 @@ command-line arguments.
 import argparse
 
 # Third-Party
-try:  # pragma: no cover
-    import pydantic.v1 as pydantic
-except ImportError:  # pragma: no cover
-    import pydantic  # type: ignore[no-redef]
+import pydantic.v1 as pydantic
 
 # Typing
 from typing import Optional

--- a/src/pydantic_argparse/parsers/boolean.py
+++ b/src/pydantic_argparse/parsers/boolean.py
@@ -7,18 +7,14 @@ command-line arguments.
 """
 
 
-# Standard
-import argparse
-
-# Third-Party
-import pydantic.v1 as pydantic
-
 # Typing
 from typing import Optional
 
 # Local
 from pydantic_argparse import utils
 from pydantic_argparse.argparse import actions
+from pydantic_argparse.compatibility import argparse
+from pydantic_argparse.compatibility import pydantic
 
 
 def should_parse(field: pydantic.fields.ModelField) -> bool:

--- a/src/pydantic_argparse/parsers/command.py
+++ b/src/pydantic_argparse/parsers/command.py
@@ -12,7 +12,7 @@ import argparse
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic
+    import pydantic.v1 as pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/src/pydantic_argparse/parsers/command.py
+++ b/src/pydantic_argparse/parsers/command.py
@@ -11,7 +11,10 @@ sub-commands.
 import argparse
 
 # Third-Party
-import pydantic
+try:  # pragma: no cover
+    import pydantic.v1 as pydantic
+except ImportError:  # pragma: no cover
+    import pydantic  # type: ignore[no-redef]
 
 # Typing
 from typing import Optional

--- a/src/pydantic_argparse/parsers/command.py
+++ b/src/pydantic_argparse/parsers/command.py
@@ -7,17 +7,13 @@ sub-commands.
 """
 
 
-# Standard
-import argparse
-
-# Third-Party
-import pydantic.v1 as pydantic
-
 # Typing
 from typing import Optional
 
 # Local
 from pydantic_argparse import utils
+from pydantic_argparse.compatibility import argparse
+from pydantic_argparse.compatibility import pydantic
 
 
 def should_parse(field: pydantic.fields.ModelField) -> bool:

--- a/src/pydantic_argparse/parsers/command.py
+++ b/src/pydantic_argparse/parsers/command.py
@@ -12,7 +12,7 @@ import argparse
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic.v1 as pydantic
+    import pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/src/pydantic_argparse/parsers/command.py
+++ b/src/pydantic_argparse/parsers/command.py
@@ -11,10 +11,7 @@ sub-commands.
 import argparse
 
 # Third-Party
-try:  # pragma: no cover
-    import pydantic.v1 as pydantic
-except ImportError:  # pragma: no cover
-    import pydantic  # type: ignore[no-redef]
+import pydantic.v1 as pydantic
 
 # Typing
 from typing import Optional

--- a/src/pydantic_argparse/parsers/container.py
+++ b/src/pydantic_argparse/parsers/container.py
@@ -14,7 +14,7 @@ import enum
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic.v1 as pydantic
+    import pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/src/pydantic_argparse/parsers/container.py
+++ b/src/pydantic_argparse/parsers/container.py
@@ -13,7 +13,10 @@ import collections.abc
 import enum
 
 # Third-Party
-import pydantic
+try:  # pragma: no cover
+    import pydantic.v1 as pydantic
+except ImportError:  # pragma: no cover
+    import pydantic  # type: ignore[no-redef]
 
 # Typing
 from typing import Optional

--- a/src/pydantic_argparse/parsers/container.py
+++ b/src/pydantic_argparse/parsers/container.py
@@ -8,18 +8,16 @@ whether this module should be used to parse the field, as well as the
 
 
 # Standard
-import argparse
 import collections.abc
 import enum
-
-# Third-Party
-import pydantic.v1 as pydantic
 
 # Typing
 from typing import Optional
 
 # Local
 from pydantic_argparse import utils
+from pydantic_argparse.compatibility import argparse
+from pydantic_argparse.compatibility import pydantic
 
 
 def should_parse(field: pydantic.fields.ModelField) -> bool:

--- a/src/pydantic_argparse/parsers/container.py
+++ b/src/pydantic_argparse/parsers/container.py
@@ -14,7 +14,7 @@ import enum
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic
+    import pydantic.v1 as pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/src/pydantic_argparse/parsers/container.py
+++ b/src/pydantic_argparse/parsers/container.py
@@ -13,10 +13,7 @@ import collections.abc
 import enum
 
 # Third-Party
-try:  # pragma: no cover
-    import pydantic.v1 as pydantic
-except ImportError:  # pragma: no cover
-    import pydantic  # type: ignore[no-redef]
+import pydantic.v1 as pydantic
 
 # Typing
 from typing import Optional

--- a/src/pydantic_argparse/parsers/enum.py
+++ b/src/pydantic_argparse/parsers/enum.py
@@ -13,7 +13,7 @@ import enum
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic.v1 as pydantic
+    import pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/src/pydantic_argparse/parsers/enum.py
+++ b/src/pydantic_argparse/parsers/enum.py
@@ -12,7 +12,10 @@ import argparse
 import enum
 
 # Third-Party
-import pydantic
+try:  # pragma: no cover
+    import pydantic.v1 as pydantic
+except ImportError:  # pragma: no cover
+    import pydantic  # type: ignore[no-redef]
 
 # Local
 from pydantic_argparse import utils

--- a/src/pydantic_argparse/parsers/enum.py
+++ b/src/pydantic_argparse/parsers/enum.py
@@ -13,7 +13,7 @@ import enum
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic
+    import pydantic.v1 as pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/src/pydantic_argparse/parsers/enum.py
+++ b/src/pydantic_argparse/parsers/enum.py
@@ -8,14 +8,12 @@ command-line arguments.
 
 
 # Standard
-import argparse
 import enum
-
-# Third-Party
-import pydantic.v1 as pydantic
 
 # Local
 from pydantic_argparse import utils
+from pydantic_argparse.compatibility import argparse
+from pydantic_argparse.compatibility import pydantic
 
 # Typing
 from typing import Optional, Type

--- a/src/pydantic_argparse/parsers/enum.py
+++ b/src/pydantic_argparse/parsers/enum.py
@@ -12,10 +12,7 @@ import argparse
 import enum
 
 # Third-Party
-try:  # pragma: no cover
-    import pydantic.v1 as pydantic
-except ImportError:  # pragma: no cover
-    import pydantic  # type: ignore[no-redef]
+import pydantic.v1 as pydantic
 
 # Local
 from pydantic_argparse import utils

--- a/src/pydantic_argparse/parsers/literal.py
+++ b/src/pydantic_argparse/parsers/literal.py
@@ -12,7 +12,7 @@ import argparse
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic
+    import pydantic.v1 as pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/src/pydantic_argparse/parsers/literal.py
+++ b/src/pydantic_argparse/parsers/literal.py
@@ -11,10 +11,7 @@ command-line arguments.
 import argparse
 
 # Third-Party
-try:  # pragma: no cover
-    import pydantic.v1 as pydantic
-except ImportError:  # pragma: no cover
-    import pydantic  # type: ignore[no-redef]
+import pydantic.v1 as pydantic
 
 # Local
 from pydantic_argparse import utils

--- a/src/pydantic_argparse/parsers/literal.py
+++ b/src/pydantic_argparse/parsers/literal.py
@@ -12,7 +12,7 @@ import argparse
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic.v1 as pydantic
+    import pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/src/pydantic_argparse/parsers/literal.py
+++ b/src/pydantic_argparse/parsers/literal.py
@@ -7,14 +7,10 @@ command-line arguments.
 """
 
 
-# Standard
-import argparse
-
-# Third-Party
-import pydantic.v1 as pydantic
-
 # Local
 from pydantic_argparse import utils
+from pydantic_argparse.compatibility import argparse
+from pydantic_argparse.compatibility import pydantic
 
 # Typing
 from typing import Optional, Literal, get_args

--- a/src/pydantic_argparse/parsers/literal.py
+++ b/src/pydantic_argparse/parsers/literal.py
@@ -11,7 +11,10 @@ command-line arguments.
 import argparse
 
 # Third-Party
-import pydantic
+try:  # pragma: no cover
+    import pydantic.v1 as pydantic
+except ImportError:  # pragma: no cover
+    import pydantic  # type: ignore[no-redef]
 
 # Local
 from pydantic_argparse import utils

--- a/src/pydantic_argparse/parsers/mapping.py
+++ b/src/pydantic_argparse/parsers/mapping.py
@@ -13,10 +13,7 @@ import ast
 import collections.abc
 
 # Third-Party
-try:  # pragma: no cover
-    import pydantic.v1 as pydantic
-except ImportError:  # pragma: no cover
-    import pydantic  # type: ignore[no-redef]
+import pydantic.v1 as pydantic
 
 # Typing
 from typing import Optional

--- a/src/pydantic_argparse/parsers/mapping.py
+++ b/src/pydantic_argparse/parsers/mapping.py
@@ -14,7 +14,7 @@ import collections.abc
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic.v1 as pydantic
+    import pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/src/pydantic_argparse/parsers/mapping.py
+++ b/src/pydantic_argparse/parsers/mapping.py
@@ -8,18 +8,16 @@ command-line arguments.
 
 
 # Standard
-import argparse
 import ast
 import collections.abc
-
-# Third-Party
-import pydantic.v1 as pydantic
 
 # Typing
 from typing import Optional
 
 # Local
 from pydantic_argparse import utils
+from pydantic_argparse.compatibility import argparse
+from pydantic_argparse.compatibility import pydantic
 
 
 def should_parse(field: pydantic.fields.ModelField) -> bool:

--- a/src/pydantic_argparse/parsers/mapping.py
+++ b/src/pydantic_argparse/parsers/mapping.py
@@ -13,7 +13,10 @@ import ast
 import collections.abc
 
 # Third-Party
-import pydantic
+try:  # pragma: no cover
+    import pydantic.v1 as pydantic
+except ImportError:  # pragma: no cover
+    import pydantic  # type: ignore[no-redef]
 
 # Typing
 from typing import Optional

--- a/src/pydantic_argparse/parsers/mapping.py
+++ b/src/pydantic_argparse/parsers/mapping.py
@@ -14,7 +14,7 @@ import collections.abc
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic
+    import pydantic.v1 as pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/src/pydantic_argparse/parsers/standard.py
+++ b/src/pydantic_argparse/parsers/standard.py
@@ -9,17 +9,13 @@ that do not match any other types and require no special handling are parsed.
 """
 
 
-# Standard
-import argparse
-
-# Third-Party
-import pydantic.v1 as pydantic
-
 # Typing
 from typing import Optional
 
 # Local
 from pydantic_argparse import utils
+from pydantic_argparse.compatibility import argparse
+from pydantic_argparse.compatibility import pydantic
 
 
 def parse_field(

--- a/src/pydantic_argparse/parsers/standard.py
+++ b/src/pydantic_argparse/parsers/standard.py
@@ -14,7 +14,7 @@ import argparse
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic.v1 as pydantic
+    import pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/src/pydantic_argparse/parsers/standard.py
+++ b/src/pydantic_argparse/parsers/standard.py
@@ -14,7 +14,7 @@ import argparse
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic
+    import pydantic.v1 as pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/src/pydantic_argparse/parsers/standard.py
+++ b/src/pydantic_argparse/parsers/standard.py
@@ -13,7 +13,10 @@ that do not match any other types and require no special handling are parsed.
 import argparse
 
 # Third-Party
-import pydantic
+try:  # pragma: no cover
+    import pydantic.v1 as pydantic
+except ImportError:  # pragma: no cover
+    import pydantic  # type: ignore[no-redef]
 
 # Typing
 from typing import Optional

--- a/src/pydantic_argparse/parsers/standard.py
+++ b/src/pydantic_argparse/parsers/standard.py
@@ -13,10 +13,7 @@ that do not match any other types and require no special handling are parsed.
 import argparse
 
 # Third-Party
-try:  # pragma: no cover
-    import pydantic.v1 as pydantic
-except ImportError:  # pragma: no cover
-    import pydantic  # type: ignore[no-redef]
+import pydantic.v1 as pydantic
 
 # Typing
 from typing import Optional

--- a/src/pydantic_argparse/utils/arguments.py
+++ b/src/pydantic_argparse/utils/arguments.py
@@ -5,8 +5,8 @@ names and formatting argument descriptions.
 """
 
 
-# Third-Party
-import pydantic.v1 as pydantic
+# Local
+from pydantic_argparse.compatibility import pydantic
 
 
 def name(field: pydantic.fields.ModelField, invert: bool = False) -> str:

--- a/src/pydantic_argparse/utils/arguments.py
+++ b/src/pydantic_argparse/utils/arguments.py
@@ -7,7 +7,7 @@ names and formatting argument descriptions.
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic
+    import pydantic.v1 as pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/src/pydantic_argparse/utils/arguments.py
+++ b/src/pydantic_argparse/utils/arguments.py
@@ -6,7 +6,10 @@ names and formatting argument descriptions.
 
 
 # Third-Party
-import pydantic
+try:  # pragma: no cover
+    import pydantic.v1 as pydantic
+except ImportError:  # pragma: no cover
+    import pydantic  # type: ignore[no-redef]
 
 
 def name(field: pydantic.fields.ModelField, invert: bool = False) -> str:

--- a/src/pydantic_argparse/utils/arguments.py
+++ b/src/pydantic_argparse/utils/arguments.py
@@ -7,7 +7,7 @@ names and formatting argument descriptions.
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic.v1 as pydantic
+    import pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/src/pydantic_argparse/utils/arguments.py
+++ b/src/pydantic_argparse/utils/arguments.py
@@ -6,10 +6,7 @@ names and formatting argument descriptions.
 
 
 # Third-Party
-try:  # pragma: no cover
-    import pydantic.v1 as pydantic
-except ImportError:  # pragma: no cover
-    import pydantic  # type: ignore[no-redef]
+import pydantic.v1 as pydantic
 
 
 def name(field: pydantic.fields.ModelField, invert: bool = False) -> str:

--- a/src/pydantic_argparse/utils/errors.py
+++ b/src/pydantic_argparse/utils/errors.py
@@ -7,7 +7,7 @@ Validation Errors to human readable messages.
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic
+    import pydantic.v1 as pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/src/pydantic_argparse/utils/errors.py
+++ b/src/pydantic_argparse/utils/errors.py
@@ -6,7 +6,10 @@ Validation Errors to human readable messages.
 
 
 # Third-Party
-import pydantic
+try:  # pragma: no cover
+    import pydantic.v1 as pydantic
+except ImportError:  # pragma: no cover
+    import pydantic  # type: ignore[no-redef]
 
 # Typing
 from typing import Union

--- a/src/pydantic_argparse/utils/errors.py
+++ b/src/pydantic_argparse/utils/errors.py
@@ -6,10 +6,7 @@ Validation Errors to human readable messages.
 
 
 # Third-Party
-try:  # pragma: no cover
-    import pydantic.v1 as pydantic
-except ImportError:  # pragma: no cover
-    import pydantic  # type: ignore[no-redef]
+import pydantic.v1 as pydantic
 
 # Typing
 from typing import Union

--- a/src/pydantic_argparse/utils/errors.py
+++ b/src/pydantic_argparse/utils/errors.py
@@ -5,8 +5,8 @@ Validation Errors to human readable messages.
 """
 
 
-# Third-Party
-import pydantic.v1 as pydantic
+# Local
+from pydantic_argparse.compatibility import pydantic
 
 # Typing
 from typing import Union

--- a/src/pydantic_argparse/utils/errors.py
+++ b/src/pydantic_argparse/utils/errors.py
@@ -7,7 +7,7 @@ Validation Errors to human readable messages.
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic.v1 as pydantic
+    import pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/src/pydantic_argparse/utils/namespaces.py
+++ b/src/pydantic_argparse/utils/namespaces.py
@@ -5,8 +5,8 @@ converting `argparse.Namespace`s to regular Python `dict`s.
 """
 
 
-# Standard
-import argparse
+# Local
+from pydantic_argparse.compatibility import argparse
 
 # Typing
 from typing import Any, Dict

--- a/src/pydantic_argparse/utils/pydantic.py
+++ b/src/pydantic_argparse/utils/pydantic.py
@@ -10,8 +10,8 @@ dynamically generated validators and environment variable parsers.
 # Standard
 import contextlib
 
-# Third-Party
-import pydantic.v1 as pydantic
+# Local
+from pydantic_argparse.compatibility import pydantic
 
 # Typing
 from typing import Any, Callable, Dict, Optional, Type, TypeVar, Union

--- a/src/pydantic_argparse/utils/pydantic.py
+++ b/src/pydantic_argparse/utils/pydantic.py
@@ -11,7 +11,10 @@ dynamically generated validators and environment variable parsers.
 import contextlib
 
 # Third-Party
-import pydantic
+try:  # pragma: no cover
+    import pydantic.v1 as pydantic
+except ImportError:  # pragma: no cover
+    import pydantic  # type: ignore[no-redef]
 
 # Typing
 from typing import Any, Callable, Dict, Optional, Type, TypeVar, Union

--- a/src/pydantic_argparse/utils/pydantic.py
+++ b/src/pydantic_argparse/utils/pydantic.py
@@ -12,7 +12,7 @@ import contextlib
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic.v1 as pydantic
+    import pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/src/pydantic_argparse/utils/pydantic.py
+++ b/src/pydantic_argparse/utils/pydantic.py
@@ -11,10 +11,7 @@ dynamically generated validators and environment variable parsers.
 import contextlib
 
 # Third-Party
-try:  # pragma: no cover
-    import pydantic.v1 as pydantic
-except ImportError:  # pragma: no cover
-    import pydantic  # type: ignore[no-redef]
+import pydantic.v1 as pydantic
 
 # Typing
 from typing import Any, Callable, Dict, Optional, Type, TypeVar, Union

--- a/src/pydantic_argparse/utils/pydantic.py
+++ b/src/pydantic_argparse/utils/pydantic.py
@@ -12,7 +12,7 @@ import contextlib
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic
+    import pydantic.v1 as pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/src/pydantic_argparse/utils/types.py
+++ b/src/pydantic_argparse/utils/types.py
@@ -7,7 +7,7 @@ comparing the types of `pydantic fields.
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic.v1 as pydantic
+    import pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/src/pydantic_argparse/utils/types.py
+++ b/src/pydantic_argparse/utils/types.py
@@ -6,10 +6,7 @@ comparing the types of `pydantic fields.
 
 
 # Third-Party
-try:  # pragma: no cover
-    import pydantic.v1 as pydantic
-except ImportError:  # pragma: no cover
-    import pydantic  # type: ignore[no-redef]
+import pydantic.v1 as pydantic
 
 # Typing
 from typing import Any, Tuple, Union, get_origin

--- a/src/pydantic_argparse/utils/types.py
+++ b/src/pydantic_argparse/utils/types.py
@@ -6,7 +6,10 @@ comparing the types of `pydantic fields.
 
 
 # Third-Party
-import pydantic
+try:  # pragma: no cover
+    import pydantic.v1 as pydantic
+except ImportError:  # pragma: no cover
+    import pydantic  # type: ignore[no-redef]
 
 # Typing
 from typing import Any, Tuple, Union, get_origin

--- a/src/pydantic_argparse/utils/types.py
+++ b/src/pydantic_argparse/utils/types.py
@@ -7,7 +7,7 @@ comparing the types of `pydantic fields.
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic
+    import pydantic.v1 as pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/src/pydantic_argparse/utils/types.py
+++ b/src/pydantic_argparse/utils/types.py
@@ -5,8 +5,8 @@ comparing the types of `pydantic fields.
 """
 
 
-# Third-Party
-import pydantic.v1 as pydantic
+# Local
+from pydantic_argparse.compatibility import pydantic
 
 # Typing
 from typing import Any, Tuple, Union, get_origin

--- a/tests/argparse/test_actions.py
+++ b/tests/argparse/test_actions.py
@@ -6,14 +6,12 @@ class by testing the expected nested namespace functionality.
 """
 
 
-# Standard
-import argparse
-
 # Third-Party
 import pytest
 
 # Local
 from pydantic_argparse.argparse import actions
+from pydantic_argparse.compatibility import argparse
 from tests import conftest as conf
 
 

--- a/tests/argparse/test_parser.py
+++ b/tests/argparse/test_parser.py
@@ -14,10 +14,7 @@ import re
 import textwrap
 
 # Third-Party
-try:  # pragma: no cover
-    import pydantic.v1 as pydantic
-except ImportError:  # pragma: no cover
-    import pydantic  # type: ignore[no-redef]
+import pydantic.v1 as pydantic
 import pytest
 
 # Local

--- a/tests/argparse/test_parser.py
+++ b/tests/argparse/test_parser.py
@@ -15,7 +15,7 @@ import textwrap
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic
+    import pydantic.v1 as pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 import pytest

--- a/tests/argparse/test_parser.py
+++ b/tests/argparse/test_parser.py
@@ -7,19 +7,19 @@ class by testing a large number of expected use-cases.
 
 
 # Standard
-import argparse
 import collections as coll
 import datetime as dt
 import re
 import textwrap
 
 # Third-Party
-import pydantic.v1 as pydantic
 import pytest
 
 # Local
 import pydantic_argparse
-import tests.conftest as conf
+from pydantic_argparse.compatibility import argparse
+from pydantic_argparse.compatibility import pydantic
+from tests import conftest as conf
 
 # Typing
 from typing import Deque, Dict, FrozenSet, List, Literal, Optional, Set, Tuple, Type, TypeVar

--- a/tests/argparse/test_parser.py
+++ b/tests/argparse/test_parser.py
@@ -15,7 +15,7 @@ import textwrap
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic.v1 as pydantic
+    import pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 import pytest

--- a/tests/argparse/test_parser.py
+++ b/tests/argparse/test_parser.py
@@ -14,7 +14,10 @@ import re
 import textwrap
 
 # Third-Party
-import pydantic
+try:  # pragma: no cover
+    import pydantic.v1 as pydantic
+except ImportError:  # pragma: no cover
+    import pydantic  # type: ignore[no-redef]
 import pytest
 
 # Local

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,16 +7,14 @@ package without needing to import them.
 
 
 # Standard
-import argparse
 import collections
 import datetime
 import enum
 
-# Third-Party
-import pydantic.v1 as pydantic
-
 # Local
 from pydantic_argparse.argparse import actions
+from pydantic_argparse.compatibility import argparse
+from pydantic_argparse.compatibility import pydantic
 
 # Typing
 from typing import Any, Deque, Dict, FrozenSet, List, Literal, Optional, Set, Tuple, Type

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ import enum
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic.v1 as pydantic
+    import pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ import enum
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic
+    import pydantic.v1 as pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,10 @@ import datetime
 import enum
 
 # Third-Party
-import pydantic
+try:  # pragma: no cover
+    import pydantic.v1 as pydantic
+except ImportError:  # pragma: no cover
+    import pydantic  # type: ignore[no-redef]
 
 # Local
 from pydantic_argparse.argparse import actions

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,10 +13,7 @@ import datetime
 import enum
 
 # Third-Party
-try:  # pragma: no cover
-    import pydantic.v1 as pydantic
-except ImportError:  # pragma: no cover
-    import pydantic  # type: ignore[no-redef]
+import pydantic.v1 as pydantic
 
 # Local
 from pydantic_argparse.argparse import actions

--- a/tests/functional/test_environment_variables.py
+++ b/tests/functional/test_environment_variables.py
@@ -6,7 +6,6 @@ environment variable parsing capabilities.
 
 
 # Standard
-import argparse
 import collections as coll
 import datetime as dt
 import os
@@ -17,7 +16,8 @@ import pytest_mock
 
 # Local
 import pydantic_argparse
-import tests.conftest as conf
+from pydantic_argparse.compatibility import argparse
+from tests import conftest as conf
 
 # Typing
 from typing import Deque, Dict, FrozenSet, List, Literal, Optional, Set, Tuple, Type, TypeVar

--- a/tests/utils/test_errors.py
+++ b/tests/utils/test_errors.py
@@ -9,10 +9,7 @@ all branches of all functions.
 import textwrap
 
 # Third-Party
-try:  # pragma: no cover
-    import pydantic.v1 as pydantic
-except ImportError:  # pragma: no cover
-    import pydantic  # type: ignore[no-redef]
+import pydantic.v1 as pydantic
 import pytest
 
 # Local

--- a/tests/utils/test_errors.py
+++ b/tests/utils/test_errors.py
@@ -10,7 +10,7 @@ import textwrap
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic
+    import pydantic.v1 as pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 import pytest

--- a/tests/utils/test_errors.py
+++ b/tests/utils/test_errors.py
@@ -9,7 +9,10 @@ all branches of all functions.
 import textwrap
 
 # Third-Party
-import pydantic
+try:  # pragma: no cover
+    import pydantic.v1 as pydantic
+except ImportError:  # pragma: no cover
+    import pydantic  # type: ignore[no-redef]
 import pytest
 
 # Local

--- a/tests/utils/test_errors.py
+++ b/tests/utils/test_errors.py
@@ -9,11 +9,11 @@ all branches of all functions.
 import textwrap
 
 # Third-Party
-import pydantic.v1 as pydantic
 import pytest
 
 # Local
 from pydantic_argparse import utils
+from pydantic_argparse.compatibility import pydantic
 from tests import conftest as conf
 
 # Typing

--- a/tests/utils/test_errors.py
+++ b/tests/utils/test_errors.py
@@ -10,7 +10,7 @@ import textwrap
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic.v1 as pydantic
+    import pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 import pytest

--- a/tests/utils/test_namespaces.py
+++ b/tests/utils/test_namespaces.py
@@ -5,11 +5,9 @@ testing all branches of all functions.
 """
 
 
-# Standard
-import argparse
-
 # Local
 from pydantic_argparse import utils
+from pydantic_argparse.compatibility import argparse
 
 
 def test_namespace_to_dict() -> None:

--- a/tests/utils/test_types.py
+++ b/tests/utils/test_types.py
@@ -77,9 +77,3 @@ def test_is_field_a(field_type: Any, expected_type: Any) -> None:
 
     # Check and Assert Field Type
     assert utils.types.is_field_a(field, expected_type)
-
-
-def test_pydantic_version() -> None:
-    """Sanity check!"""
-    import pydantic
-    assert pydantic.__version__.startswith("2")

--- a/tests/utils/test_types.py
+++ b/tests/utils/test_types.py
@@ -12,7 +12,7 @@ import enum
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic
+    import pydantic.v1 as pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 import pytest

--- a/tests/utils/test_types.py
+++ b/tests/utils/test_types.py
@@ -11,11 +11,11 @@ import collections.abc
 import enum
 
 # Third-Party
-import pydantic.v1 as pydantic
 import pytest
 
 # Local
 from pydantic_argparse import utils
+from pydantic_argparse.compatibility import pydantic
 from tests import conftest as conf
 
 # Typing

--- a/tests/utils/test_types.py
+++ b/tests/utils/test_types.py
@@ -77,3 +77,9 @@ def test_is_field_a(field_type: Any, expected_type: Any) -> None:
 
     # Check and Assert Field Type
     assert utils.types.is_field_a(field, expected_type)
+
+
+def test_pydantic_version() -> None:
+    """Sanity check!"""
+    import pydantic
+    assert pydantic.__version__.startswith("2")

--- a/tests/utils/test_types.py
+++ b/tests/utils/test_types.py
@@ -11,7 +11,10 @@ import collections.abc
 import enum
 
 # Third-Party
-import pydantic
+try:  # pragma: no cover
+    import pydantic.v1 as pydantic
+except ImportError:  # pragma: no cover
+    import pydantic  # type: ignore[no-redef]
 import pytest
 
 # Local

--- a/tests/utils/test_types.py
+++ b/tests/utils/test_types.py
@@ -12,7 +12,7 @@ import enum
 
 # Third-Party
 try:  # pragma: no cover
-    import pydantic.v1 as pydantic
+    import pydantic
 except ImportError:  # pragma: no cover
     import pydantic  # type: ignore[no-redef]
 import pytest

--- a/tests/utils/test_types.py
+++ b/tests/utils/test_types.py
@@ -11,10 +11,7 @@ import collections.abc
 import enum
 
 # Third-Party
-try:  # pragma: no cover
-    import pydantic.v1 as pydantic
-except ImportError:  # pragma: no cover
-    import pydantic  # type: ignore[no-redef]
+import pydantic.v1 as pydantic
 import pytest
 
 # Local


### PR DESCRIPTION
## Changes
* Implements `compatibility` subpackage for easier version compatibility maintenance
* Adds Pydantic v1 / Pydantic v2 compatibility via shim
* Adds Pydantic v1 / Pydantic v2 to testing CI matrix
* Updates examples and adds compatibility notice

## Notes
* This is **not** _true_ Pydantic v2 compatibility, rather just an interim measure to ensure this package stops blocking dependency upgrades.