### PR TITLE
Chore: Update `hatch` in CI

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -28,7 +28,7 @@ jobs:
           path: .venv
           key: venv-${{ runner.os }}-3.12-${{ hashFiles('pyproject.toml') }}
       - name: Install Hatch
-        run: pip install git+https://github.com/pypa/hatch.git@master
+        run: pip install hatch
       - name: Run Build Hooks
         run: hatch build --hooks-only
       - name: Run Format

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
           path: .venv
           key: venv-${{ runner.os }}-3.12-${{ hashFiles('pyproject.toml') }}
       - name: Install Hatch
-        run: pip install git+https://github.com/pypa/hatch.git@master
+        run: pip install hatch
       - name: Run Build Hooks
         run: hatch build --hooks-only
       - name: Run Lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           path: .venv
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.pydantic-version }}-${{ hashFiles('pyproject.toml') }}
       - name: Install Hatch
-        run: pip install git+https://github.com/pypa/hatch.git@master
+        run: pip install hatch
       - name: Install Pydantic
         run: hatch run uv pip install pydantic~=${{ matrix.pydantic-version }}
       - name: Run Build Hooks

--- a/.github/workflows/type.yml
+++ b/.github/workflows/type.yml
@@ -28,7 +28,7 @@ jobs:
           path: .venv
           key: venv-${{ runner.os }}-3.12-${{ hashFiles('pyproject.toml') }}
       - name: Install Hatch
-        run: pip install git+https://github.com/pypa/hatch.git@master
+        run: pip install hatch
       - name: Run Build Hooks
         run: hatch build --hooks-only
       - name: Run Type Checking


### PR DESCRIPTION
## Changes
* Updates CI to use new `hatch` `1.10` release in place of `git@master` installation