### PR TITLE
Chore: Revert back to `macos-latest` in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        os: [ "ubuntu-latest", "macos-13", "windows-latest" ]
+        os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
         pydantic-version: [ "1.0", "2.0" ]
       fail-fast: false


### PR DESCRIPTION
## Changes
* We pinned to `macos-13` because of some Python compatibility issues which are no longer relevant.
* This PR reverts us back to `macos-latest` (which at the current time is `macos-14`.