### PR TITLE
Fix: CI Python Version

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Set Hatch Python Version
-        run: echo "HATCH_PYTHON=$(which python)" >> $GITHUB_ENV
+        run: echo "HATCH_PYTHON=$(where python)" >> $GITHUB_ENV
       - name: Cache Dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,11 +18,12 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Setup Python
+        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - name: Set Hatch Python Version
-        run: echo "HATCH_PYTHON=$(where python)" >> $GITHUB_ENV
+        run: echo "HATCH_PYTHON=${{ steps.setup-python.outputs.python-path }}" >> $GITHUB_ENV
       - name: Cache Dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Set Hatch Python Version
-        run: echo "HATCH_PYTHON=3.12" >> $GITHUB_ENV
+        run: echo "HATCH_PYTHON=$(which python)" >> $GITHUB_ENV
       - name: Cache Dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,6 +21,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Set Hatch Python Version
+        run: echo "HATCH_PYTHON=3.12" >> $GITHUB_ENV
       - name: Cache Dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Set Hatch Python Version
-        run: echo "HATCH_PYTHON=$(which python)" >> $GITHUB_ENV
+        run: echo "HATCH_PYTHON=$(where python)" >> $GITHUB_ENV
       - name: Cache Dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,11 +18,12 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Setup Python
+        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - name: Set Hatch Python Version
-        run: echo "HATCH_PYTHON=$(where python)" >> $GITHUB_ENV
+        run: echo "HATCH_PYTHON=${{ steps.setup-python.outputs.python-path }}" >> $GITHUB_ENV
       - name: Cache Dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Set Hatch Python Version
-        run: echo "HATCH_PYTHON=3.12" >> $GITHUB_ENV
+        run: echo "HATCH_PYTHON=$(which python)" >> $GITHUB_ENV
       - name: Cache Dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Set Hatch Python Version
+        run: echo "HATCH_PYTHON=3.12" >> $GITHUB_ENV
       - name: Cache Dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set Hatch Python Version
-        run: echo "HATCH_PYTHON=$(which python)" >> $GITHUB_ENV
+        run: echo "HATCH_PYTHON=$(where python)" >> $GITHUB_ENV
       - name: Cache Dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,11 @@ jobs:
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.pydantic-version }}-${{ hashFiles('pyproject.toml') }}
       - name: Install Hatch
         uses: pypa/hatch@install
+      - name: Debug Information
+        run: |
+          hatch run python --version
+          hatch run uv --version
+          hatch run uv pip --version
       - name: Install Pydantic
         run: hatch run uv pip install pydantic~=${{ matrix.pydantic-version }}
       - name: Run Build Hooks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,11 +27,12 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Setup Python
+        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set Hatch Python Version
-        run: echo "HATCH_PYTHON=$(where python)" >> $GITHUB_ENV
+        run: echo "HATCH_PYTHON=${{ steps.setup-python.outputs.python-path }}" >> $GITHUB_ENV
       - name: Cache Dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: 0 0 * * 0
 
+env:
+  UV_SYSTEM_PYTHON=true
+
 jobs:
   test:
     name: Test
@@ -30,6 +33,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Set Hatch Python Version
+        run: echo "HATCH_PYTHON=${{ matrix.python-version }}" >> $GITHUB_ENV
       - name: Cache Dependencies
         uses: actions/cache@v4
         with:
@@ -37,11 +42,6 @@ jobs:
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.pydantic-version }}-${{ hashFiles('pyproject.toml') }}
       - name: Install Hatch
         uses: pypa/hatch@install
-      - name: Debug Information
-        run: |
-          hatch run python --version
-          hatch run uv --version
-          hatch run uv pip --version
       - name: Install Pydantic
         run: hatch run uv pip install pydantic~=${{ matrix.pydantic-version }}
       - name: Run Build Hooks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,6 @@ on:
   schedule:
     - cron: 0 0 * * 0
 
-env:
-  UV_SYSTEM_PYTHON=true
-
 jobs:
   test:
     name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set Hatch Python Version
-        run: echo "HATCH_PYTHON=${{ matrix.python-version }}" >> $GITHUB_ENV
+        run: echo "HATCH_PYTHON=$(which python)" >> $GITHUB_ENV
       - name: Cache Dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/type.yml
+++ b/.github/workflows/type.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Set Hatch Python Version
-        run: echo "HATCH_PYTHON=$(which python)" >> $GITHUB_ENV
+        run: echo "HATCH_PYTHON=$(where python)" >> $GITHUB_ENV
       - name: Cache Dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/type.yml
+++ b/.github/workflows/type.yml
@@ -18,11 +18,12 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Setup Python
+        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - name: Set Hatch Python Version
-        run: echo "HATCH_PYTHON=$(where python)" >> $GITHUB_ENV
+        run: echo "HATCH_PYTHON=${{ steps.setup-python.outputs.python-path }}" >> $GITHUB_ENV
       - name: Cache Dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/type.yml
+++ b/.github/workflows/type.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Set Hatch Python Version
-        run: echo "HATCH_PYTHON=3.12" >> $GITHUB_ENV
+        run: echo "HATCH_PYTHON=$(which python)" >> $GITHUB_ENV
       - name: Cache Dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/type.yml
+++ b/.github/workflows/type.yml
@@ -21,6 +21,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Set Hatch Python Version
+        run: echo "HATCH_PYTHON=3.12" >> $GITHUB_ENV
       - name: Cache Dependencies
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Changes

It turns out that Hatch does **not** default to the Python version of the current shell. This means that our CI was always defaulting to the version of Python that Hatch was installed with, which at the current time is always `3.12`. This was completely silent, until some weird caching things broke.

This PR sets the `HATCH_PYTHON` environment variable to the output of the `actions/setup-python` step, so that Hatch uses the Python version that we want.

See:
* https://github.com/pypa/hatch/blob/hatch-v1.12.0/src/hatch/env/virtual.py#L317-L335
* https://github.com/pypa/hatch/issues/1543
* https://github.com/pypa/hatch/issues/1541
* https://hatch.pypa.io/dev/plugins/environment/virtual/#python-resolution
* https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#python-version